### PR TITLE
Added (mostly on archival basis) the Dockerfile which uses a locally …

### DIFF
--- a/docker/Dockerfile-unity-luseepy-legacy
+++ b/docker/Dockerfile-unity-luseepy-legacy
@@ -1,0 +1,32 @@
+##### USED PRIMARILY TO BUILD THE "UNITY FOUNDATION" IMAGE
+#
+# 
+# Note a copy of the "astropy cache"
+
+FROM lusee/lusee-night-refspec-cppyy:1.0
+
+ARG reqs=requirements-unity-luseepy.txt
+
+ADD .astropy /root/.astropy
+
+WORKDIR /data
+
+WORKDIR /user/luseepy
+
+COPY docker/${reqs} requirements.txt
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+#
+# Important:
+RUN pip install jupyterlab
+#
+RUN rm requirements.txt
+#
+COPY lusee lusee
+COPY tests tests
+#
+ENV REFSPEC_PATH=/user/refspec
+ENV PYTHONPATH=/user/luseepy:$PYTHONPATH
+ENV LUSEE_DRIVE_DIR=/data/
+#
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,13 @@ docker build . -f docker/Dockerfile -t lusee/lusee-night-unity-luseepy:0.1 --bui
 ```
 
 
+### The legacy dockerfile
+
+There is an appropriately labeled `legacy` Dockerfile, which differs
+from the main official one in that it's using a locally cached data in the
+`.astropy` folder. This file is kept to give the user a bit more flexibility
+in how these data are managed.
+
 ### Jupyter - approach one
 This image also includes __Jupyter Lab__ software. Jupyter
 is not started automatically, i.e. by default the user gets `bash` running and a functional


### PR DESCRIPTION
I added a "legacy" version of the Dockerfile which uses a cached copy of .astropy. It's not the main "official" version of the Dockerfile but convenient to have if one is rebuilding images locally and frequently. We can improve this later.
