### PR TITLE
change self.obs.lunar_day (not defined)

### DIFF
--- a/lusee/Simulation.py
+++ b/lusee/Simulation.py
@@ -211,7 +211,7 @@ class Simulator:
         fits = fitsio.FITS(out_file,'rw',clobber=True)
         header = {
             "version":      0.1,
-            "lunar_day":    self.obs.lunar_day,
+            "lunar_day":    self.obs.time_range,
             "lun_lat_deg":  self.obs.lun_lat_deg,
             "lun_long_deg": self.obs.lun_long_deg,
             "lun_height_m": self.obs.lun_height_m,


### PR DESCRIPTION
minor bug fix
`Simulator.obs.lunar_day` is never defined
Most likely refers to `Simulator.obs.time_range`

Noticed this when trying to run `python driver/run_sim.py config/realistic_example.yaml' 
![Pasted image 20240401134739](https://github.com/lusee-night/luseepy/assets/72617859/fbf437c2-e545-4b39-b6a5-7267383a6bfb)

Not sure if this affects any other behavior elsewhere. Please review