### PR TITLE
add pyproject.toml lines to make this a package

### DIFF
--- a/lusee/__init__.py
+++ b/lusee/__init__.py
@@ -1,3 +1,4 @@
+"""A package for simulation of LuSEE-Night."""
 # -- FIXME --
 
 # -mxp- commented out some imports since the hardcoded cache breaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,19 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "luseepy"
+name = "lusee"
 authors = [{name = "Potekhin", email = "potekhin@bnl.gov"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
+dependencies = [
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "astropy",
+    "fitsio",
+    "pyshtools",
+    "healpy",
+    "lunarsky"
+]


### PR DESCRIPTION
This PR adds some lines to pyproject.toml so that one can install this as a package with 
```
flit install
```
for i.e. local development.