### PR TITLE
Update run_sim.py

### DIFF
--- a/simulation/driver/run_sim.py
+++ b/simulation/driver/run_sim.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
-import  lusee
-import  numpy  as np
-import  healpy as hp
-import  pickle
-import  os,sys
-import  yaml
-from    yaml.loader import SafeLoader
+if __name__ == "__main__":
+    import  lusee
+    import  numpy  as np
+    import  healpy as hp
+    import  pickle
+    import  os,sys
+    import  yaml
+    from    yaml.loader import SafeLoader
 
 #######################
 class SimDriver(dict):


### PR DESCRIPTION
concurrent.futures misbehaves with Python 3.8+ on MacOS (https://stackoverflow.com/questions/76292341/concurrent-futures-misbehaves-on-python-3-8-on-mac-os). Running run_sim.py on MacOS with Python 3.8+ raises a concurrent.futures.process.BrokenProcessPool exception. This exception can be avoided with putting import statements under `if __name__ == '__main__'` guards.  