### PR TITLE
CroSimulator jax.grad

### DIFF
--- a/lusee/CroSimulator.py
+++ b/lusee/CroSimulator.py
@@ -1,177 +1,344 @@
+"""
+CroSimulator — JAX-differentiable radio telescope simulator.
+
+The constructor precomputes observation-fixed quantities (MEPA rotation
+matrices, time-evolution phases).  ``simulate()`` takes the differentiable
+inputs — beam ALMs, sky ALMs, ground temperature, ground power — as
+explicit arguments, so ``jax.jit`` and ``jax.grad`` work naturally::
+
+    sim = CroSimulator(obs, beams, sky, Tground=0, ...)
+    wf  = sim.simulate(sim.beam_alms, sim.sky_mepa,
+                       sim.Tground, sim.ground_power)
+
+    # gradient w.r.t. beam ALMs
+    grad_fn = jax.grad(lambda b: jnp.sum(
+        sim.simulate(b, sim.sky_mepa, sim.Tground, sim.ground_power) ** 2))
+    g = grad_fn(sim.beam_alms)
+"""
+
 from functools import partial
 import warnings
 
-from .Observation import Observation
-from .Beam import Beam
-from .BeamCouplings import BeamCouplings
-from .SimulatorBase import SimulatorBase, default_plot_sky_beam_dir, get_topo_z_rotation_angles
-import numpy as np
-import fitsio
-import sys
-import os
-import jax.numpy as jnp
-import croissant as cro
-import croissant.jax as crojax
 import jax
-from lunarsky import LunarTopo
+import jax.numpy as jnp
+import numpy as np
+import os
+import sys
+
+import croissant as cro
 import s2fft
+from lunarsky import LunarTopo
 
-"""
-CroSimulator: same inputs as DefaultSimulator (beam, sky, obs, etc.) but uses
-the Croissant engine for the actual simulation (MEPA frame, rot_alm_z phases,
-crojax.simulator.convolve). Freq, time range, and antenna location come from
-the observation object (config). Croissant currently supports single
-polarization / single dipole per beam; one beam combination at a time
-"""
+from .BeamCouplings import BeamCouplings
 
 
-class CroSimulator(SimulatorBase):
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _default_plot_dir():
+    """Default save directory for diagnostic plots."""
+    return os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "..", "simulation", "output", "figures")
+    )
+
+
+def _prepare_beams(beams, combinations, lmax, freq_ndx_beam,
+                   cross_power=None, extra_opts=None):
+    """Prepare beam ALM products for all antenna combinations.
+
+    Returns a list of (i, j, beamreal, beamimag, groundPowerReal,
+    groundPowerImag) tuples.
     """
-    Croissant simulator: same inputs as DefaultSimulator (obs, beams, sky_model,
-    combinations, freq, lmax) 
+    if cross_power is None:
+        cross_power = BeamCouplings()
+    if extra_opts is None:
+        extra_opts = {}
+    efbeams = []
+    combinations = [(int(i), int(j)) for i, j in combinations]
+    for i, j in combinations:
+        bi, bj = beams[i], beams[j]
+        print(f"  intializing beam combination {bi.id} x {bj.id} ...")
+        norm = np.sqrt(bi.gain_conv[freq_ndx_beam] * bj.gain_conv[freq_ndx_beam])
+        beamreal, beamimag = bi.get_healpix_alm(
+            lmax, freq_ndx=freq_ndx_beam, other=bj,
+            return_I_stokes_only=True, return_complex_components=True,
+        )
+        beamreal = beamreal * norm[:, None]
+        if beamimag is not None:
+            beamimag = beamimag * norm[:, None]
+        if i == j:
+            groundPowerReal = np.array([1 - np.real(br[0]) / np.sqrt(4 * np.pi)
+                                        for br in beamreal])
+            beamimag = None
+            groundPowerImag = 0.0
+        else:
+            cp = cross_power.Ex_coupling(bi, bj, freq_ndx_beam)
+            print(f"    cross power is {cp[0]} ... {cp[-1]} ")
+            groundPowerReal = np.array([c - np.real(br[0]) / np.sqrt(4 * np.pi)
+                                        for br, c in zip(beamreal, cp)])
+            groundPowerImag = np.array([0 - np.real(bi_[0]) / np.sqrt(4 * np.pi)
+                                        for bi_ in beamimag])
+        if "dump_beams" in extra_opts:
+            np.save(bi.id + bj.id, beamreal)
+        efbeams.append((i, j, beamreal, beamimag, groundPowerReal, groundPowerImag))
+    return efbeams
 
-    - Freq, time grid, and antenna location are taken from the observation
-      object (set from config). [luseepy.observation class]
-    - Lunar topo frame is built from obs class (obstime=first time, location=obs.loc).
-    - Beam and sky are transformed to MEPA; time evolution uses
-      crojax.simulator.rot_alm_z (moon sidereal rotation).
-    - Croissant handles single polarization / single dipole per beam; each
-      combination is convolved separately to match DefaultSimulator output shape.
-    - Sky gal→MEPA once (epoch-aware), beam topo(t0)→MEPA once, rot_alm_z(dt) for time evolution, then convolve.
-    - Output layout is (N_times, N_combos, N_freq).
 
-    :param obs: Observation (time range, deltaT_sec, lun_lat_deg, lun_long_deg)
-    :param beams: Instrument beams [luseepy.beam class]
-    :param sky_model: Sky model [luseepy.skymodels class]
-    :param combinations: Beam combination indices [(0,0),(1,1),(0,2),(1,3),(1,2)]
-    :param lmax: Maximum l
-    :param Tground: Ground temperature [K]
-    :param freq: Frequencies in MHz (from config / obs)
-    :param cross_power: BeamCouplings for cross terms [luseepy.BeamCouplings class]
-    :param extra_opts: optional dict, e.g. cache_transform, dump_beams (see DefaultSimulator),
-        freq_idx_plot (int): index of frequency at which to plot sky and beam.
+def _hp_to_2d(alms, sim_L):
+    """Convert a stack of healpy-packed ALMs to s2fft 2D layout."""
+    return jnp.stack([
+        s2fft.sampling.reindex.flm_hp_to_2d_fast(jnp.asarray(a), sim_L)
+        for a in alms
+    ])
+
+
+def _plot_sky_beam_healpix(sky_alm, beam_alm, nside, lmax,
+                           save_dir="output/figures",
+                           save_filename="sky_beam_healpix_cro.png",
+                           title_prefix=""):
+    """Plot sky and beam as healpix mollweide maps (side-effect, not JAX)."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import healpy as hp
+
+    outpath = os.path.join(save_dir, save_filename)
+    os.makedirs(save_dir, exist_ok=True)
+    sky_map = hp.alm2map(np.asarray(sky_alm, dtype=np.complex128), nside, lmax=lmax)
+    beam_map = hp.alm2map(np.asarray(beam_alm, dtype=np.complex128), nside, lmax=lmax)
+    plt.figure(figsize=(12, 5))
+    hp.mollview(sky_map, title=(title_prefix + " Sky").strip(), sub=(1, 2, 1))
+    hp.mollview(beam_map, title=(title_prefix + " Beam").strip(), sub=(1, 2, 2))
+    plt.savefig(outpath, dpi=120, bbox_inches="tight")
+    plt.close()
+    print(f"  plot_sky_and_beam: saved {outpath}")
+
+
+# ---------------------------------------------------------------------------
+# CroSimulator
+# ---------------------------------------------------------------------------
+
+class CroSimulator:
+    """JAX-differentiable Croissant simulator.
+
+    The constructor precomputes observation-fixed quantities and stores
+    default values for the differentiable inputs as attributes.
+    ``simulate()`` takes those differentiable inputs as explicit arguments,
+    making ``jax.jit`` / ``jax.grad`` straightforward.
+
+    Precomputed (fixed per observation, stored on ``self``):
+        ``eul_topo``, ``dl_topo``, ``phases`` — MEPA rotation & time phases.
+
+    Default differentiable arrays (also stored on ``self`` for convenience):
+        ``beam_alms``, ``sky_mepa``, ``Tground``, ``ground_power``.
+
+    :param obs: Observation (time range, location).
+    :param beams: Instrument beams (lusee.Beam / BeamGauss).
+    :param sky_model: Sky model (must have ``frame == "galactic"``).
+    :param Tground: Ground temperature [K].
+    :param combinations: Beam combination indices, e.g. ``[(0,0),(1,1),(0,2)]``.
+    :param freq: Frequencies in MHz (default: from beams).
+    :param lmax: Maximum spherical harmonic degree.
+    :param cross_power: BeamCouplings for cross terms.
+    :param extra_opts: Dict for plotting / dump_beams options.
     """
 
-    def __init__ (self, obs, beams, sky_model, Tground = 200.0,
-                  combinations = [(0,0),(1,1),(0,2),(1,3),(1,2)], freq = None,
-                  lmax = 128, cross_power = None,
-                  extra_opts = {}):
-        super().__init__(obs, beams, sky_model, Tground, combinations, freq)
+    def __init__(self, obs, beams, sky_model, Tground=200.0,
+                 combinations=((0, 0), (1, 1), (0, 2), (1, 3), (1, 2)),
+                 freq=None, lmax=128, cross_power=None, extra_opts=None):
+        if extra_opts is None:
+            extra_opts = {}
+
+        # ── frequency index setup ──
+        if freq is None:
+            freq = beams[0].freq
+        freq = np.asarray(freq)
+        freq_ndx_beam = []
+        freq_ndx_sky = []
+        for f in freq:
+            try:
+                ndx = list(beams[0].freq).index(f)
+            except ValueError:
+                print(f"Error: Frequency {f} does not exist in beams.")
+                sys.exit(1)
+            freq_ndx_beam.append(ndx)
+            try:
+                ndx = list(sky_model.freq).index(f)
+            except ValueError:
+                print(f"Error: Frequency {f} does not exist in sky model.")
+                sys.exit(1)
+            freq_ndx_sky.append(ndx)
+
         self.lmax = lmax
-        self.extra_opts = extra_opts
-        self.cross_power = cross_power if (cross_power is not None) else BeamCouplings()
-        self.prepare_beams (beams, combinations)
+        self.freq = freq
+        self._freq_ndx_beam = freq_ndx_beam
 
-            
-                                
-    def simulate(self, times=None):
-        """
-        Simulate using Croissant.
-        freq, time grid, and antenna location from
-        observation; beam and sky transformed to MEPA; rot_alm_z phases;
-        crojax.simulator.convolve for sky and beam convolution.
-        :param times: List of times; if None, use self.obs.times (from config).
-        :returns: Waterfall (N_times, N_combos_with_imag, N_freq), same as DefaultSimulator.
-        """
-        if times is None:
-            times = self.obs.times
-        ntimes = len(times)
-        delta_t = float(self.obs.deltaT_sec)
+        # prepare beams (numpy) to stack into JAX arrays
+        combinations = [(int(i), int(j)) for i, j in combinations]
+        self._combinations = combinations
+        efbeams = _prepare_beams(
+            beams, combinations, lmax, freq_ndx_beam,
+            cross_power=cross_power, extra_opts=extra_opts,
+        )
 
-        if self.sky_model.frame != "galactic":
+        sim_L = lmax + 1
+        all_beam_2d = []
+        all_ground = []
+        channel_layout = []
+        for ci, cj, beamreal, beamimag, gpr, gpi in efbeams:
+            all_beam_2d.append(_hp_to_2d(beamreal, sim_L))
+            all_ground.append(np.asarray(gpr))
+            channel_layout.append(f"{ci}{cj}R")
+            if ci != cj:
+                all_beam_2d.append(_hp_to_2d(beamimag, sim_L))
+                all_ground.append(np.asarray(gpi))
+                channel_layout.append(f"{ci}{cj}I")
+
+        self.beam_alms = jnp.stack(all_beam_2d)       # (Nch, Nf, L, 2L-1)
+        self.ground_power = jnp.stack(all_ground)      # (Nch, Nf)
+        self.Tground = jnp.asarray(float(Tground))
+        self.channel_layout = tuple(channel_layout)
+
+        # ── MEPA setup (fixed per observation) ──
+        if sky_model.frame != "galactic":
             raise NotImplementedError(
-                f"CroSimulator requires galactic sky frame, got {self.sky_model.frame}"
+                f"CroSimulator requires galactic sky frame, got {sky_model.frame}"
             )
-        self.result = self._simulate_croissant_mepa(times, ntimes, delta_t)
-        return self.result
+        times = obs.times
+        topo = LunarTopo(obstime=times[0], location=obs.loc)
+        eul_topo, dl_topo = cro.rotations.generate_euler_dl(lmax, topo, "mepa")
+        self.eul_topo = tuple(float(a) for a in eul_topo)
+        self.dl_topo = jnp.asarray(dl_topo)
 
-    def _simulate_croissant_mepa(self, times, ntimes, delta_t):
-        """MEPA pipeline: sky gal→MEPA once (epoch-aware), beam topo(t0)→MEPA once,
-        rot_alm_z(dt) for time evolution, then convolve."""
-        topo = LunarTopo(obstime=times[0], location=self.obs.loc)
-        sim_L = self.lmax + 1
-        eul_topo, dl_topo = crojax.rotations.generate_euler_dl(
-            self.lmax, topo, "mepa"
-        )
-        topo2mepa = partial(
-            s2fft.utils.rotation.rotate_flms,
-            L=sim_L,
-            rotation=eul_topo,
-            dl_array=dl_topo,
-        )
-        sky_gal = self.sky_model.get_alm(self.freq_ndx_sky, self.freq)
-        sky_2d = np.stack([
-            np.asarray(
-                s2fft.sampling.reindex.flm_hp_to_2d_fast(jnp.asarray(s_), sim_L)
-            )
-            for s_ in sky_gal
+        sky_gal = sky_model.get_alm(freq_ndx_sky, freq)
+        sky_2d = jnp.stack([
+            s2fft.sampling.reindex.flm_hp_to_2d_fast(jnp.asarray(s), sim_L)
+            for s in sky_gal
         ])
         et = cro.rotations.jd_to_et(times[0].jd)
-        sky_mepa = cro.rotations.gal2mepa(sky_2d, et=et)
-        delta_t_sec = np.arange(len(times), dtype=float) * self.obs.deltaT_sec
-        phases = cro.simulator.rot_alm_z(self.lmax, times=delta_t_sec)
-        norm_factor = 4.0 * np.pi
-        # croissant>=5.1.x handles LunarTopo (NEU) to ENU convention
-        # internally in rotations.get_rot_mat/generate_euler_dl.
-        # Do not apply an additional manual m-dependent phase here.
-        combo_results = []
-        plot_done = False
-        for ci, cj, beamreal, beamimag, groundPowerReal, groundPowerImag in self.efbeams:
-            beam_2d = np.stack([
-                np.asarray(
-                    s2fft.sampling.reindex.flm_hp_to_2d_fast(
-                        jnp.asarray(br_), sim_L
-                    )
-                )
-                for br_ in beamreal
-            ])
-            beam_mepa = jax.vmap(topo2mepa)(jnp.array(beam_2d))
-            if self.extra_opts.get("plot_sky_and_beam") and not plot_done:
-                nf = len(self.freq)
-                freq_idx_plot = int(self.extra_opts.get("freq_idx_plot", 0))
-                if nf == 0:
-                    raise ValueError("Cannot plot: no frequencies in self.freq")
-                if not (0 <= freq_idx_plot < nf):
-                    clamped = max(0, min(freq_idx_plot, nf - 1))
-                    warnings.warn(
-                        f"freq_idx_plot={freq_idx_plot} is out of bounds for "
-                        f"len(freq)={nf}; using {clamped}.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    freq_idx_plot = clamped
-                nside = getattr(self.sky_model, "Nside", 64)
-                sky_packed = s2fft.sampling.reindex.flm_2d_to_hp_fast(np.asarray(sky_mepa[freq_idx_plot]), self.lmax+1)
-                beam_packed = s2fft.sampling.reindex.flm_2d_to_hp_fast(np.asarray(beam_mepa[freq_idx_plot]), self.lmax+1)
-                self._plot_sky_beam_healpix(
-                    sky_packed, beam_packed, nside, self.lmax,
-                    save_dir=self.extra_opts.get("plot_dir", default_plot_sky_beam_dir()),
-                    save_filename=self.extra_opts.get("plot_filename", "sky_beam_healpix_cro.png"),
-                    title_prefix=f"Croissant at {self.freq[freq_idx_plot]} MHz ",
-                )
-                plot_done = True
-            vis = crojax.simulator.convolve(beam_mepa, sky_mepa, phases)
-            T = np.asarray(vis.real) / norm_factor + self.Tground * groundPowerReal
-            combo_results.append((T, None))
-            if ci != cj:
-                beamimag_2d = np.stack([
-                    np.asarray(
-                        s2fft.sampling.reindex.flm_hp_to_2d_fast(
-                            jnp.asarray(bi_), sim_L
-                        )
-                    )
-                    for bi_ in beamimag
-                ])
-                beamimag_mepa = jax.vmap(topo2mepa)(jnp.array(beamimag_2d))
-                vis_imag = crojax.simulator.convolve(beamimag_mepa, sky_mepa, phases)
-                Timag = np.asarray(vis_imag.real) / norm_factor + self.Tground * groundPowerImag
-                combo_results[-1] = (T, Timag)
-        wfall = []
-        for ti in range(ntimes):
-            res = []
-            for T, Timag in combo_results:
-                res.append(T[ti])
-                if Timag is not None:
-                    res.append(Timag[ti])
-            wfall.append(res)
-        return np.array(wfall)
+        self.sky_mepa = jnp.asarray(cro.rotations.gal2mepa(sky_2d, et=et))
+
+        delta_t_sec = np.arange(len(times), dtype=float) * obs.deltaT_sec
+        self.phases = jnp.asarray(cro.simulator.rot_alm_z(lmax, times=delta_t_sec))
+        self._nside = getattr(sky_model, "Nside", 64)
+
+        # ── I/O metadata ──
+        self._obs_meta = {
+            "version":      0.1,
+            "lunar_day":    obs.time_range,
+            "lun_lat_deg":  obs.lun_lat_deg,
+            "lun_long_deg": obs.lun_long_deg,
+            "lun_height_m": obs.lun_height_m,
+            "deltaT_sec":   obs.deltaT_sec,
+        }
+        self._beams_ZReIm = tuple(
+            (b.ZRe[freq_ndx_beam], b.ZIm[freq_ndx_beam]) for b in beams
+        )
+
+    # -----------------------------------------------------------------
+    # Pure-JAX simulation
+    # -----------------------------------------------------------------
+
+    def simulate(self, beam_alms=None, sky_mepa=None,
+                 Tground=None, ground_power=None):
+        """Run the beam-sky convolution.
+
+        All arguments are optional — defaults come from the values computed
+        in ``__init__``.  Pass explicit JAX arrays to differentiate through
+        them with ``jax.grad``.
+
+        **Pure JAX** when called with explicit arguments (no Python
+        side-effects, compatible with ``jax.jit`` / ``jax.grad``).
+
+        :param beam_alms: ``(Nchannels, Nfreq, L, 2L-1)`` beam ALMs in
+            topo-frame s2fft 2D layout.
+        :param sky_mepa: ``(Nfreq, L, 2L-1)`` sky ALMs in MEPA frame.
+            The galactic→MEPA rotation is a fixed linear transform applied
+            once in ``__init__``; sampling/optimizing in MEPA avoids
+            repeating that rotation every forward pass and the gradient
+            landscape is identical (just rotated).
+        :param Tground: Scalar ground temperature [K].
+        :param ground_power: ``(Nchannels, Nfreq)`` ground power fractions.
+        :returns: Waterfall array, shape ``(Ntimes, Nchannels, Nfreq)``.
+        """
+        if beam_alms is None:
+            beam_alms = self.beam_alms
+        if sky_mepa is None:
+            sky_mepa = self.sky_mepa
+        if Tground is None:
+            Tground = self.Tground
+        if ground_power is None:
+            ground_power = self.ground_power
+
+        sim_L = self.lmax + 1
+        topo2mepa = partial(
+            s2fft.utils.rotation.rotate_flms,
+            L=sim_L, rotation=self.eul_topo, dl_array=self.dl_topo,
+        )
+        # Rotate all beam channels: vmap over channels, then over freqs.
+        beam_mepa = jax.vmap(jax.vmap(topo2mepa))(beam_alms)
+        # Convolve all channels with sky at once.
+        vis = cro.multipair.multi_convolve(beam_mepa, sky_mepa, self.phases)
+        # vis: (Nchannels, Ntimes, Nfreq)
+        T = vis.real / (4.0 * jnp.pi) + Tground * ground_power[:, None, :]
+        return jnp.moveaxis(T, 0, 1)   # (Ntimes, Nchannels, Nfreq)
+
+    # -----------------------------------------------------------------
+    # I/O
+    # -----------------------------------------------------------------
+
+    def write_fits(self, out_file, result=None):
+        """Write simulation result to FITS.
+
+        :param out_file: Output file path.
+        :param result: Waterfall array; if *None*, calls ``simulate()``.
+        """
+        import fitsio
+        if result is None:
+            result = self.simulate()
+        fits = fitsio.FITS(out_file, 'rw', clobber=True)
+        fits.write(np.asarray(result), header=self._obs_meta, extname='data')
+        fits.write(np.asarray(self.freq), extname='freq')
+        fits.write(np.array(self._combinations), extname='combinations')
+        for i, (zre, zim) in enumerate(self._beams_ZReIm):
+            fits.write(np.asarray(zre), extname=f'ZRe_{i}')
+            fits.write(np.asarray(zim), extname=f'ZIm_{i}')
+
+    # -----------------------------------------------------------------
+    # Diagnostics
+    # -----------------------------------------------------------------
+
+    def plot_sky_beam(self, freq_idx=0, save_dir=None, save_filename=None):
+        """Plot sky and beam at one frequency as healpix mollweide maps.
+
+        :param freq_idx: Frequency index to plot.
+        :param save_dir: Output directory (default: simulation/output/figures).
+        :param save_filename: Output filename.
+        """
+        sim_L = self.lmax + 1
+        nf = len(self.freq)
+        if nf == 0:
+            raise ValueError("Cannot plot: no frequencies")
+        if not (0 <= freq_idx < nf):
+            freq_idx = max(0, min(freq_idx, nf - 1))
+            warnings.warn(
+                f"freq_idx={freq_idx} out of bounds for len(freq)={nf}.",
+                UserWarning, stacklevel=2,
+            )
+        topo2mepa = partial(
+            s2fft.utils.rotation.rotate_flms,
+            L=sim_L, rotation=self.eul_topo, dl_array=self.dl_topo,
+        )
+        beam0_mepa = jax.vmap(topo2mepa)(self.beam_alms[0])
+        sky_packed = s2fft.sampling.reindex.flm_2d_to_hp_fast(
+            np.asarray(self.sky_mepa[freq_idx]), sim_L)
+        beam_packed = s2fft.sampling.reindex.flm_2d_to_hp_fast(
+            np.asarray(beam0_mepa[freq_idx]), sim_L)
+        _plot_sky_beam_healpix(
+            sky_packed, beam_packed, self._nside, self.lmax,
+            save_dir=save_dir or _default_plot_dir(),
+            save_filename=save_filename or "sky_beam_healpix_cro.png",
+            title_prefix=f"Croissant at {self.freq[freq_idx]} MHz ",
+        )

--- a/lusee/CroSimulator.py
+++ b/lusee/CroSimulator.py
@@ -212,13 +212,15 @@ class CroSimulator:
         self.eul_topo = tuple(float(a) for a in eul_topo)
         self.dl_topo = jnp.asarray(dl_topo)
 
+        self._freq_ndx_sky = freq_ndx_sky
+        self._et = cro.rotations.jd_to_et(times[0].jd)
+
         sky_gal = sky_model.get_alm(freq_ndx_sky, freq)
         sky_2d = jnp.stack([
             s2fft.sampling.reindex.flm_hp_to_2d_fast(jnp.asarray(s), sim_L)
             for s in sky_gal
         ])
-        et = cro.rotations.jd_to_et(times[0].jd)
-        self.sky_mepa = jnp.asarray(cro.rotations.gal2mepa(sky_2d, et=et))
+        self.sky_mepa = jnp.asarray(cro.rotations.gal2mepa(sky_2d, et=self._et))
 
         delta_t_sec = np.arange(len(times), dtype=float) * obs.deltaT_sec
         self.phases = jnp.asarray(cro.simulator.rot_alm_z(lmax, times=delta_t_sec))
@@ -242,27 +244,43 @@ class CroSimulator:
     # -----------------------------------------------------------------
 
     def simulate(self, beam_alms=None, sky_mepa=None,
-                 Tground=None, ground_power=None):
+                 Tground=None, ground_power=None, *,
+                 beam=None, sky=None):
         """Run the beam-sky convolution.
 
         All arguments are optional — defaults come from the values computed
         in ``__init__``.  Pass explicit JAX arrays to differentiate through
         them with ``jax.grad``.
 
-        **Pure JAX** when called with explicit arguments (no Python
-        side-effects, compatible with ``jax.jit`` / ``jax.grad``).
+        **Pytree interface** (preferred): pass ``beam=`` and/or ``sky=``
+        with pytree objects.  The simulator calls their methods inside the
+        traced computation so ``jax.grad`` sees through to the pytree
+        leaves::
 
+            grad = jax.grad(lambda s: jnp.sum(sim.simulate(sky=s) ** 2))(sky)
+
+        **Raw-array interface**: pass ``beam_alms=``, ``sky_mepa=``, etc.
+        directly as JAX arrays (backward-compatible).
+
+        :param beam: A pytree beam object with ``.beam_alms`` and
+            ``.ground_power`` attributes.
+        :param sky: A pytree sky object with ``.get_alm(ndx, freq)`` and
+            ``.frame`` (must be ``"galactic"``).  The galactic→MEPA
+            rotation runs inside the traced computation.
         :param beam_alms: ``(Nchannels, Nfreq, L, 2L-1)`` beam ALMs in
             topo-frame s2fft 2D layout.
         :param sky_mepa: ``(Nfreq, L, 2L-1)`` sky ALMs in MEPA frame.
-            The galactic→MEPA rotation is a fixed linear transform applied
-            once in ``__init__``; sampling/optimizing in MEPA avoids
-            repeating that rotation every forward pass and the gradient
-            landscape is identical (just rotated).
         :param Tground: Scalar ground temperature [K].
         :param ground_power: ``(Nchannels, Nfreq)`` ground power fractions.
         :returns: Waterfall array, shape ``(Ntimes, Nchannels, Nfreq)``.
         """
+        if beam is not None:
+            beam_alms = beam.beam_alms
+            ground_power = beam.ground_power
+        if sky is not None:
+            sky_hp = sky.get_alm(self._freq_ndx_sky, self.freq)
+            sky_mepa = cro.rotations.gal2mepa(
+                _hp_to_2d(sky_hp, self.lmax + 1), et=self._et)
         if beam_alms is None:
             beam_alms = self.beam_alms
         if sky_mepa is None:

--- a/lusee/SkyModels.py
+++ b/lusee/SkyModels.py
@@ -306,3 +306,28 @@ class HarmonicPointSourceSky:
         if freq is not None:
             assert np.all(self.freq[ndx] == np.atleast_1d(freq))
         return [self._alm * self._T[i] for i in ndx]
+
+    # -- JAX pytree protocol --
+
+    def tree_flatten(self):
+        children = (self._T, self._alm)
+        aux = (self.lmax, self.frame, tuple(float(f) for f in self.freq))
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        lmax, frame, freq_tuple = aux
+        obj = object.__new__(cls)
+        obj._T = children[0]
+        obj._alm = children[1]
+        obj.lmax = lmax
+        obj.frame = frame
+        obj.freq = np.array(freq_tuple)
+        return obj
+
+
+try:
+    import jax
+    jax.tree_util.register_pytree_node_class(HarmonicPointSourceSky)
+except ImportError:
+    pass

--- a/simulation/driver/run_Cro_sim.py
+++ b/simulation/driver/run_Cro_sim.py
@@ -182,13 +182,24 @@ class SimDriver(dict):
 
         print(f"  Simulating {len(O.times)} timesteps (from observation) x {len(combs)} data products x {len(self.freq)} frequency bins...")
         print("  Simulating...")
-        S.simulate(times=O.times)
-
-        out_base = self["simulation"].get("output", f"sim_{engine.capitalize()}_output.fits")
-        fname = os.path.join(self.outdir, out_base)
-
-        print ("Writing to",fname)
-        S.write_fits(fname)
+        if engine == "croissant":
+            result = S.simulate()
+            if self["simulation"].get("plot_sky_and_beam"):
+                S.plot_sky_beam(
+                    freq_idx=int(self["simulation"].get("freq_idx_plot", 0)),
+                    save_dir=self["simulation"].get("plot_dir"),
+                    save_filename=self["simulation"].get("plot_filename"),
+                )
+            out_base = self["simulation"].get("output", f"sim_{engine.capitalize()}_output.fits")
+            fname = os.path.join(self.outdir, out_base)
+            print("Writing to", fname)
+            S.write_fits(fname, result=result)
+        else:
+            S.simulate(times=O.times)
+            out_base = self["simulation"].get("output", f"sim_{engine.capitalize()}_output.fits")
+            fname = os.path.join(self.outdir, out_base)
+            print("Writing to", fname)
+            S.write_fits(fname)
 
 
 

--- a/simulation/driver/sim_driver.py
+++ b/simulation/driver/sim_driver.py
@@ -217,9 +217,21 @@ class SimDriver(dict):
             f"data products x {len(self.freq)} frequency bins..."
         )
         print("  Simulating...")
-        S.simulate(times=O.times)
-
-        out_base = self["simulation"].get("output", f"sim_{engine}_output.fits")
-        fname = os.path.join(self.outdir, out_base)
-        print("Writing to", fname)
-        S.write_fits(fname)
+        if engine == "croissant":
+            result = S.simulate()
+            if self["simulation"].get("plot_sky_and_beam"):
+                S.plot_sky_beam(
+                    freq_idx=int(self["simulation"].get("freq_idx_plot", 0)),
+                    save_dir=self["simulation"].get("plot_dir"),
+                    save_filename=self["simulation"].get("plot_filename"),
+                )
+            out_base = self["simulation"].get("output", f"sim_{engine}_output.fits")
+            fname = os.path.join(self.outdir, out_base)
+            print("Writing to", fname)
+            S.write_fits(fname, result=result)
+        else:
+            S.simulate(times=O.times)
+            out_base = self["simulation"].get("output", f"sim_{engine}_output.fits")
+            fname = os.path.join(self.outdir, out_base)
+            print("Writing to", fname)
+            S.write_fits(fname)

--- a/tests/test_cro_vs_default.py
+++ b/tests/test_cro_vs_default.py
@@ -184,8 +184,7 @@ def run_comparison(config_path=None):
         cross_power=setup["cross_power"],
         extra_opts=setup.get("extra_opts", {}),
     )
-    cro_sim.simulate()
-    out_cro = cro_sim.result
+    out_cro = np.asarray(cro_sim.simulate())
 
     # Step 1: Sky raw
     print("\n" + "=" * 60)

--- a/tests/test_crosimulator.py
+++ b/tests/test_crosimulator.py
@@ -8,6 +8,43 @@ jax.config.update("jax_enable_x64", True)
 import lusee
 
 
+# ---- AmplitudeBeam pytree (test-only) ----
+
+@jax.tree_util.register_pytree_node_class
+class AmplitudeBeam:
+    """Beam with known shape, unknown scalar amplitude.
+
+    Minimal pytree example: only ``amplitude`` is differentiated.
+    """
+
+    def __init__(self, amplitude, beam_alms, ground_power):
+        self.amplitude = jnp.asarray(float(amplitude))
+        self._beam_alms_fixed = jnp.asarray(beam_alms)
+        self._ground_power_fixed = jnp.asarray(ground_power)
+
+    @property
+    def beam_alms(self):
+        return self.amplitude * jax.lax.stop_gradient(self._beam_alms_fixed)
+
+    @property
+    def ground_power(self):
+        gp0 = jax.lax.stop_gradient(self._ground_power_fixed)
+        return 1.0 - self.amplitude * (1.0 - gp0)
+
+    def tree_flatten(self):
+        children = (self.amplitude, self._beam_alms_fixed, self._ground_power_fixed)
+        return children, ()
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        amplitude, beam_alms, ground_power = children
+        obj = object.__new__(cls)
+        obj.amplitude = amplitude
+        obj._beam_alms_fixed = beam_alms
+        obj._ground_power_fixed = ground_power
+        return obj
+
+
 # ---- helpers ----
 
 def _make_sim():
@@ -223,3 +260,180 @@ def test_explicit_args_match_defaults():
                                sim.Tground, sim.ground_power)
     np.testing.assert_allclose(
         np.asarray(wf_default), np.asarray(wf_explicit), atol=1e-12)
+
+
+# ---- AmplitudeBeam pytree tests ----
+
+def test_amplitude_beam_at_unity_matches_default():
+    """AmplitudeBeam with amplitude=1 reproduces the default simulation."""
+    sim, *_ = _make_sim()
+    ab = AmplitudeBeam(1.0, sim.beam_alms, sim.ground_power)
+
+    wf_default = sim.simulate()
+    wf_pytree = sim.simulate(beam=ab)
+    np.testing.assert_allclose(
+        np.asarray(wf_default), np.asarray(wf_pytree), atol=1e-12)
+
+
+def test_amplitude_beam_scaling():
+    """AmplitudeBeam with amplitude=2 scales the waterfall (Tground=0)."""
+    sim, *_ = _make_sim()
+    ab1 = AmplitudeBeam(1.0, sim.beam_alms, sim.ground_power)
+    ab2 = AmplitudeBeam(2.0, sim.beam_alms, sim.ground_power)
+
+    wf1 = sim.simulate(beam=ab1)
+    wf2 = sim.simulate(beam=ab2)
+    # With Tground=0, waterfall is linear in beam: wf(2*beam) = 2*wf(beam)
+    np.testing.assert_allclose(np.asarray(wf2), 2.0 * np.asarray(wf1), rtol=1e-10)
+
+
+def test_amplitude_beam_grad_returns_pytree():
+    """jax.grad w.r.t. AmplitudeBeam returns an AmplitudeBeam gradient object."""
+    sim, *_ = _make_sim()
+    ab = AmplitudeBeam(1.0, sim.beam_alms, sim.ground_power)
+
+    @jax.jit
+    def loss(beam):
+        return jnp.sum(sim.simulate(beam=beam).real ** 2)
+
+    grad = jax.grad(loss)(ab)
+
+    # The gradient is an AmplitudeBeam instance
+    assert isinstance(grad, AmplitudeBeam)
+    # The amplitude gradient is a scalar
+    assert grad.amplitude.shape == ()
+    assert jnp.isfinite(grad.amplitude)
+    assert jnp.abs(grad.amplitude) > 0
+
+
+def test_amplitude_beam_grad_finite_diff():
+    """Finite-difference check on AmplitudeBeam.amplitude gradient."""
+    sim, *_ = _make_sim()
+
+    def make_beam(a):
+        return AmplitudeBeam(a, sim.beam_alms, sim.ground_power)
+
+    @jax.jit
+    def loss(beam):
+        return jnp.sum(sim.simulate(beam=beam).real ** 2)
+
+    a0 = 1.0
+    grad = jax.grad(loss)(make_beam(a0))
+    analytic = float(grad.amplitude)
+
+    eps = 1e-5
+    fd = float((loss(make_beam(a0 + eps)) - loss(make_beam(a0 - eps))) / (2 * eps))
+    np.testing.assert_allclose(analytic, fd, rtol=1e-4)
+
+
+def test_amplitude_beam_jit_grad():
+    """JIT + grad through AmplitudeBeam works in a single call."""
+    sim, *_ = _make_sim()
+    ab = AmplitudeBeam(1.0, sim.beam_alms, sim.ground_power)
+
+    grad_fn = jax.jit(jax.grad(
+        lambda b: jnp.sum(sim.simulate(beam=b).real ** 2)))
+
+    g1 = grad_fn(ab)
+    g2 = grad_fn(ab)
+    # Same input → same gradient (deterministic)
+    np.testing.assert_allclose(float(g1.amplitude), float(g2.amplitude), atol=1e-12)
+
+
+# ---- Sky pytree tests (HarmonicPointSourceSky) ----
+
+def _make_point_source_sim():
+    """Simulator with a HarmonicPointSourceSky."""
+    if lusee.CroSimulator is None:
+        pytest.skip("croissant/s2fft not installed")
+
+    lmax = 23
+    freq = np.array([5.0, 10.0, 15.0], dtype=float)
+
+    sky = lusee.HarmonicPointSourceSky(
+        lmax=lmax, freq=freq, T=[1.0, 2.0, 3.0],
+        l_deg=45.0, b_deg=10.0,
+    )
+
+    beam = lusee.BeamGauss(
+        alt_deg=90.0, az_deg=0.0, sigma_deg=20.0,
+        one_over_freq_scaling=False, id="beam",
+    )
+
+    obs = lusee.Observation(
+        "2025-03-01 00:00:00 to 2025-03-01 06:00:00",
+        deltaT_sec=7200.0, lun_lat_deg=0.0, lun_long_deg=0.0,
+    )
+
+    sim = lusee.CroSimulator(
+        obs, [beam], sky, Tground=0.0,
+        combinations=[(0, 0)], freq=freq, lmax=lmax,
+    )
+    return sim, sky
+
+
+def test_sky_pytree_matches_default():
+    """simulate(sky=sky_obj) matches simulate() when sky is the same."""
+    sim, sky = _make_point_source_sim()
+
+    wf_default = sim.simulate()
+    wf_pytree = sim.simulate(sky=sky)
+    np.testing.assert_allclose(
+        np.asarray(wf_default), np.asarray(wf_pytree), rtol=1e-10)
+
+
+def test_sky_pytree_grad_returns_sky_object():
+    """jax.grad w.r.t. HarmonicPointSourceSky returns a sky gradient object."""
+    sim, sky = _make_point_source_sim()
+
+    @jax.jit
+    def loss(s):
+        return jnp.sum(sim.simulate(sky=s).real ** 2)
+
+    grad = jax.grad(loss)(sky)
+
+    assert isinstance(grad, lusee.HarmonicPointSourceSky)
+    assert grad._T.shape == sky._T.shape
+    assert jnp.all(jnp.isfinite(grad._T))
+    assert jnp.any(jnp.abs(grad._T) > 0)
+
+
+def test_sky_pytree_grad_finite_diff():
+    """Finite-difference check on HarmonicPointSourceSky._T gradient."""
+    sim, sky = _make_point_source_sim()
+
+    @jax.jit
+    def loss(s):
+        return jnp.sum(sim.simulate(sky=s).real ** 2)
+
+    grad = jax.grad(loss)(sky)
+
+    # FD check on the element with largest gradient
+    idx = int(jnp.argmax(jnp.abs(grad._T)))
+    eps = 1e-5
+    T_jax = jnp.asarray(sky._T)
+    alm_jax = jnp.asarray(sky._alm)
+    sky_plus = lusee.HarmonicPointSourceSky.tree_unflatten(
+        sky.tree_flatten()[1],
+        (T_jax.at[idx].add(eps), alm_jax),
+    )
+    sky_minus = lusee.HarmonicPointSourceSky.tree_unflatten(
+        sky.tree_flatten()[1],
+        (T_jax.at[idx].add(-eps), alm_jax),
+    )
+    fd = float((loss(sky_plus) - loss(sky_minus)) / (2 * eps))
+    np.testing.assert_allclose(float(grad._T[idx]), fd, rtol=1e-4)
+
+
+def test_sky_pytree_scaling():
+    """Doubling source amplitude doubles the waterfall (Tground=0, linear)."""
+    sim, sky = _make_point_source_sim()
+
+    sky_2x = lusee.HarmonicPointSourceSky.tree_unflatten(
+        sky.tree_flatten()[1],
+        (sky._T * 2.0, sky._alm),
+    )
+
+    wf1 = sim.simulate(sky=sky)
+    wf2 = sim.simulate(sky=sky_2x)
+    np.testing.assert_allclose(np.asarray(wf2), 2.0 * np.asarray(wf1), rtol=1e-10)

--- a/tests/test_crosimulator.py
+++ b/tests/test_crosimulator.py
@@ -1,10 +1,17 @@
 import numpy as np
 import pytest
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
 
 import lusee
 
 
-def test_crosimulator_runs_and_returns_expected_shape():
+# ---- helpers ----
+
+def _make_sim():
+    """Shared small simulation fixture."""
     if lusee.CroSimulator is None:
         pytest.skip("croissant/s2fft not installed")
 
@@ -12,7 +19,6 @@ def test_crosimulator_runs_and_returns_expected_shape():
     lmax = 3 * nside - 1
     freq = np.array([5.0, 10.0, 15.0], dtype=float)
 
-    # Deterministic full-sky galactic map at each frequency.
     npix = 12 * nside * nside
     base_map = np.ones(npix, dtype=float)
     maps = [base_map * t for t in (1.0, 2.0, 3.0)]
@@ -42,8 +48,178 @@ def test_crosimulator_runs_and_returns_expected_shape():
         freq=freq,
         lmax=lmax,
     )
-    result = sim.simulate(times=obs.times)
+    return sim, obs, beam, freq, lmax
+
+
+# ---- tests ----
+
+def test_crosimulator_runs_and_returns_expected_shape():
+    sim, obs, _, freq, _ = _make_sim()
+    result = sim.simulate()
 
     assert result.shape == (len(obs.times), 1, len(freq))
     assert np.all(np.isfinite(result))
     assert np.any(np.abs(result) > 0.0)
+
+
+def test_crosimulator_jit():
+    """jax.jit works on simulate with explicit args."""
+    sim, *_ = _make_sim()
+
+    @jax.jit
+    def run(beam_alms, sky_mepa):
+        return sim.simulate(beam_alms, sky_mepa)
+
+    result_jit = run(sim.beam_alms, sim.sky_mepa)
+    result_eager = sim.simulate()
+    np.testing.assert_allclose(
+        np.asarray(result_jit), np.asarray(result_eager), atol=1e-12)
+
+
+def test_crosimulator_grad_beam():
+    """jax.grad(sum(waterfall²)) w.r.t. beam_alms matches finite differences."""
+    sim, *_ = _make_sim()
+
+    @jax.jit
+    def loss(beam_alms):
+        wf = sim.simulate(beam_alms)
+        return jnp.sum(wf.real ** 2)
+
+    grad = jax.grad(loss)(sim.beam_alms)
+    assert grad.shape == sim.beam_alms.shape
+    assert jnp.any(jnp.abs(grad) > 0)
+
+    # Finite-difference check on the element with largest gradient
+    grad_real = grad.real
+    idx = np.unravel_index(int(jnp.argmax(jnp.abs(grad_real))), grad.shape)
+    eps = 1e-5
+    fd = float(
+        (loss(sim.beam_alms.at[idx].add(eps))
+         - loss(sim.beam_alms.at[idx].add(-eps))) / (2 * eps)
+    )
+    np.testing.assert_allclose(float(grad_real[idx]), fd, rtol=1e-4)
+
+
+def test_crosimulator_grad_sky():
+    """jax.grad w.r.t. sky_mepa works."""
+    sim, *_ = _make_sim()
+
+    @jax.jit
+    def loss(sky_mepa):
+        return jnp.sum(sim.simulate(sky_mepa=sky_mepa).real ** 2)
+
+    grad = jax.grad(loss)(sim.sky_mepa)
+    assert grad.shape == sim.sky_mepa.shape
+    assert jnp.any(jnp.abs(grad) > 0)
+
+
+def test_crosimulator_grad_Tground():
+    """jax.grad w.r.t. Tground works (requires nonzero ground_power)."""
+    sim, *_ = _make_sim()
+    # Use nonzero ground power so Tground actually affects the output.
+    gp = jnp.ones_like(sim.ground_power) * 0.1
+
+    @jax.jit
+    def loss(Tg):
+        return jnp.sum(sim.simulate(Tground=Tg, ground_power=gp).real ** 2)
+
+    grad = jax.grad(loss)(jnp.array(200.0))
+    assert jnp.isfinite(grad)
+    assert jnp.abs(grad) > 0
+
+
+# ---- default / override patterns ----
+
+def test_defaults_held_constant():
+    """Gradient w.r.t. beam_alms does not change when sky is default vs explicit
+    (same value) — verifies defaults are treated as constants correctly."""
+    sim, *_ = _make_sim()
+
+    def loss_default_sky(beam_alms):
+        return jnp.sum(sim.simulate(beam_alms) ** 2)
+
+    def loss_explicit_sky(beam_alms):
+        return jnp.sum(sim.simulate(beam_alms, sky_mepa=sim.sky_mepa) ** 2)
+
+    g1 = jax.grad(loss_default_sky)(sim.beam_alms)
+    g2 = jax.grad(loss_explicit_sky)(sim.beam_alms)
+    np.testing.assert_allclose(np.asarray(g1), np.asarray(g2), atol=1e-12)
+
+
+def test_grad_beam_sky_independent():
+    """Perturbing sky should not affect the beam gradient when sky is a default
+    (closed-over constant), but SHOULD affect it when sky is explicit."""
+    sim, *_ = _make_sim()
+
+    # Grad w.r.t. beam with default sky
+    def loss_beam_only(b):
+        return jnp.sum(sim.simulate(b) ** 2)
+    g_default = jax.grad(loss_beam_only)(sim.beam_alms)
+
+    # Grad w.r.t. beam with a scaled sky passed explicitly
+    sky_scaled = sim.sky_mepa * 2.0
+    def loss_beam_with_sky(b):
+        return jnp.sum(sim.simulate(b, sky_mepa=sky_scaled) ** 2)
+    g_scaled = jax.grad(loss_beam_with_sky)(sim.beam_alms)
+
+    # These should differ because the sky changed the forward pass
+    assert not jnp.allclose(g_default, g_scaled)
+
+
+def test_grad_sky_with_default_beam():
+    """Grad w.r.t. sky while beam is held at default, with FD check."""
+    sim, *_ = _make_sim()
+
+    @jax.jit
+    def loss(sky):
+        return jnp.sum(sim.simulate(sky_mepa=sky).real ** 2)
+
+    grad = jax.grad(loss)(sim.sky_mepa)
+    grad_real = grad.real
+    idx = np.unravel_index(int(jnp.argmax(jnp.abs(grad_real))), grad.shape)
+    eps = 1e-5
+    fd = float(
+        (loss(sim.sky_mepa.at[idx].add(eps))
+         - loss(sim.sky_mepa.at[idx].add(-eps))) / (2 * eps)
+    )
+    np.testing.assert_allclose(float(grad_real[idx]), fd, rtol=1e-4)
+
+
+def test_grad_beam_and_sky_simultaneous():
+    """Gradient w.r.t. beam and sky simultaneously via a tuple arg."""
+    sim, *_ = _make_sim()
+
+    @jax.jit
+    def loss(beam_and_sky):
+        b, s = beam_and_sky
+        return jnp.sum(sim.simulate(b, s) ** 2)
+
+    grad_b, grad_s = jax.grad(loss)((sim.beam_alms, sim.sky_mepa))
+    assert grad_b.shape == sim.beam_alms.shape
+    assert grad_s.shape == sim.sky_mepa.shape
+    assert jnp.any(jnp.abs(grad_b) > 0)
+    assert jnp.any(jnp.abs(grad_s) > 0)
+
+
+def test_grad_ground_power_with_defaults():
+    """Grad w.r.t. ground_power while beam/sky are defaults."""
+    sim, *_ = _make_sim()
+    Tg = jnp.array(200.0)
+
+    @jax.jit
+    def loss(gp):
+        return jnp.sum(sim.simulate(Tground=Tg, ground_power=gp).real ** 2)
+
+    grad = jax.grad(loss)(sim.ground_power)
+    assert grad.shape == sim.ground_power.shape
+    assert jnp.all(jnp.isfinite(grad))
+
+
+def test_explicit_args_match_defaults():
+    """Passing all defaults explicitly produces the same result as no args."""
+    sim, *_ = _make_sim()
+    wf_default = sim.simulate()
+    wf_explicit = sim.simulate(sim.beam_alms, sim.sky_mepa,
+                               sim.Tground, sim.ground_power)
+    np.testing.assert_allclose(
+        np.asarray(wf_default), np.asarray(wf_explicit), atol=1e-12)

--- a/tests/test_lunar_28day_Cro_vs_default.py
+++ b/tests/test_lunar_28day_Cro_vs_default.py
@@ -99,26 +99,24 @@ def test_lunar_day_28_single_source():
     cro_sim = lusee.CroSimulator(
         obs, beams, sky,
         Tground=Tground,
-        combinations= [(0, 0)],
+        combinations=[(0, 0)],
         freq=freq,
         lmax=lmax,
-        extra_opts={
-            "plot_sky_and_beam": True,
-            "freq_idx_plot": 5,
-            "plot_dir": str(_LUSEEPY_ROOT / "simulation" / "output" / "figures"),
-            "plot_filename": "sky_beam_healpix_cro_single_pixel.png",
-        },
     )
-    cro_sim.simulate(times=times)
+    cro_result = cro_sim.simulate()
+    cro_sim.plot_sky_beam(
+        freq_idx=5,
+        save_dir=str(_LUSEEPY_ROOT / "simulation" / "output" / "figures"),
+        save_filename="sky_beam_healpix_cro_single_pixel.png",
+    )
 
     out_dir = str(_LUSEEPY_ROOT / "simulation" / "output")
-    cro_sim.write_fits(os.path.join(out_dir, "sim_output_cro_singlepixel_28days.fits"))
+    cro_sim.write_fits(os.path.join(out_dir, "sim_output_cro_singlepixel_28days.fits"), result=cro_result)
     def_sim.write_fits(os.path.join(out_dir, "sim_output_default_singlepixel_28days.fits"))
 
-    assert cro_sim.result.shape == def_sim.result.shape
-
-    np_cro_result = np.asarray(cro_sim.result)
+    np_cro_result = np.asarray(cro_result)
     np_def_result = np.asarray(def_sim.result)
+    assert np_cro_result.shape == np_def_result.shape
     diff_norm = np.linalg.norm(np_cro_result - np_def_result)
     rel = diff_norm / np.linalg.norm(np_def_result)
     assert rel < 5e-3

--- a/tests/test_transit_cases.py
+++ b/tests/test_transit_cases.py
@@ -116,13 +116,13 @@ def test_transit_cases():
             freq=FREQ,
             lmax=LMAX,
         )
-        cro_sim.simulate(times=times)
+        cro_result = cro_sim.simulate()
         cro_path = str(out_dir / f"sim_output_cro_case_{name}.fits")
-        cro_sim.write_fits(cro_path)
+        cro_sim.write_fits(cro_path, result=cro_result)
 
         # freq-averaged time stream: shape (Ntimes,)
         def_freq_avg = np.mean(def_sim.result[:, 0, :], axis=1)
-        cro_freq_avg = np.mean(cro_sim.result[:, 0, :], axis=1)
+        cro_freq_avg = np.mean(np.asarray(cro_result)[:, 0, :], axis=1)
 
         def_max = def_freq_avg.max()
         cro_max = cro_freq_avg.max()


### PR DESCRIPTION
CroSimulator no longer inherits SimulatorBase. Instead, it is created with arbitrary defaults, and you can take gradients through simulate(). 

Defaults come from the constructor, which precomputes observation-fixed quantities (the rotation phases). This makes jax.jit and jax.grad work on any subset of inputs for simulate(), unspecified args are closed-over constants.